### PR TITLE
feat : add static website for listing assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,9 +121,9 @@ jobs:
           for OUTPUT in *; do
             DL_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/${{ steps.next_ver_code.outputs.NEXT_VER_CODE }}/${OUTPUT}"
             if [[ $OUTPUT = *.apk ]]; then
-              APKS+="${NL}📦[${OUTPUT}](${DL_URL})"
+              APKS+="${NL}�[${OUTPUT}](${DL_URL})"
             elif [[ $OUTPUT = *.zip ]]; then
-              MODULES+="${NL}📦[${OUTPUT}](${DL_URL})"
+              MODULES+="${NL}�[${OUTPUT}](${DL_URL})"
             fi
           done
           MODULES=${MODULES#"$NL"}
@@ -145,3 +145,103 @@ jobs:
           MSG=${MSG:0:9450}
           POST="https://api.telegram.org/bot${TG_TOKEN}/sendMessage"
           curl -X POST --data-urlencode "parse_mode=Markdown" --data-urlencode "disable_web_page_preview=true" --data-urlencode "text=${MSG}" --data-urlencode "chat_id=${TG_CHAT}" "$POST"
+
+      - name: Generate GitHub Pages index.html
+        run: |
+          mkdir -p docs
+          cat <<EOF > docs/index.html
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>ReVanced Apps - Latest Release</title>
+              <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+              <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+              <style>
+                  body {
+                      display: flex;
+                      min-height: 100vh;
+                      flex-direction: column;
+                  }
+                  main {
+                      flex: 1 0 auto;
+                  }
+                  .container {
+                      margin-top: 50px;
+                  }
+              </style>
+          </head>
+          <body>
+              <nav>
+                  <div class="nav-wrapper">
+                      <a href="#" class="brand-logo center">ReVanced Apps</a>
+                  </div>
+              </nav>
+              <main>
+                  <div class="container">
+                      <h4>Latest Release</h4>
+                      <table class="highlight">
+                          <thead>
+                              <tr>
+                                  <th>Name</th>
+                                  <th>Version</th>
+                                  <th>Link</th>
+                              </tr>
+                          </thead>
+                          <tbody id="release-table">
+                              <!-- Data will be populated here -->
+                          </tbody>
+                      </table>
+                  </div>
+              </main>
+              <footer class="page-footer">
+                  <div class="container">
+                      <div class="row">
+                          <div class="col l6 s12">
+                              <h5 class="white-text">ReVanced Apps</h5>
+                              <p class="grey-text text-lighten-4">Listing all assets from the latest release.</p>
+                          </div>
+                      </div>
+                  </div>
+              </footer>
+              <script>
+                  document.addEventListener('DOMContentLoaded', function() {
+                      fetch('https://api.github.com/repos/${{ github.repository }}/releases/latest')
+                          .then(response => response.json())
+                          .then(data => {
+                              const table = document.getElementById('release-table');
+                              data.assets.forEach(asset => {
+                                  const row = document.createElement('tr');
+                                  const nameCell = document.createElement('td');
+                                  const versionCell = document.createElement('td');
+                                  const linkCell = document.createElement('td');
+                                  const link = document.createElement('a');
+
+                                  nameCell.textContent = asset.name;
+                                  versionCell.textContent = data.tag_name;
+                                  link.href = asset.browser_download_url;
+                                  link.textContent = 'Download';
+                                  link.target = '_blank';
+
+                                  linkCell.appendChild(link);
+                                  row.appendChild(nameCell);
+                                  row.appendChild(versionCell);
+                                  row.appendChild(linkCell);
+                                  table.appendChild(row);
+                              });
+                          })
+                          .catch(error => console.error('Error fetching release data:', error));
+                  });
+              </script>
+              <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+          </body>
+          </html>
+          EOF
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: main
+          skip_checkout: true
+          file_pattern: docs/index.html
+          commit_message: Update GitHub Pages with latest release information

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Install and update directly from android with [Obtainium](https://github.com/Imr
 </ul>
 
 Use [**zygisk-detach**](https://github.com/j-hc/zygisk-detach) to detach YouTube and YT Music from Play Store if you are using magisk modules. 
+
+## Static Website
+
+We now have a [static website](https://V1ck3s.github.io/revanced-apps) hosted on GitHub Pages. This website lists all assets from the latest release, including their name, version, and download link, in a table with a material design style. Check it out for a beautiful and easy-to-navigate view of the latest ReVanced apps.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ReVanced Apps - Latest Release</title>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+    <style>
+        body {
+            display: flex;
+            min-height: 100vh;
+            flex-direction: column;
+            background-color: #121212;
+            color: #ffffff;
+            font-family: 'Courier New', Courier, monospace;
+        }
+        main {
+            flex: 1 0 auto;
+        }
+        .container {
+            margin-top: 50px;
+        }
+        .nav-wrapper {
+            background-color: #1e1e1e;
+        }
+        .brand-logo {
+            font-family: 'Courier New', Courier, monospace;
+        }
+        .highlight > tbody > tr:hover {
+            background-color: #333333;
+        }
+        .page-footer {
+            background-color: #1e1e1e;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <div class="nav-wrapper">
+            <a href="#" class="brand-logo center">ReVanced Apps</a>
+        </div>
+    </nav>
+    <main>
+        <div class="container">
+            <h4>Latest Release</h4>
+            <table class="highlight">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Version</th>
+                        <th>Link</th>
+                    </tr>
+                </thead>
+                <tbody id="release-table">
+                    <!-- Data will be populated here -->
+                </tbody>
+            </table>
+        </div>
+    </main>
+    <footer class="page-footer">
+        <div class="container">
+            <div class="row">
+                <div class="col l6 s12">
+                    <h5 class="white-text">ReVanced Apps</h5>
+                    <p class="grey-text text-lighten-4">Listing all assets from the latest release.</p>
+                </div>
+            </div>
+        </div>
+    </footer>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            fetch('https://api.github.com/repos/V1ck3s/revanced-apps/releases/latest')
+                .then(response => response.json())
+                .then(data => {
+                    const table = document.getElementById('release-table');
+                    data.assets.forEach(asset => {
+                        const row = document.createElement('tr');
+                        const nameCell = document.createElement('td');
+                        const versionCell = document.createElement('td');
+                        const linkCell = document.createElement('td');
+                        const link = document.createElement('a');
+
+                        const nameParts = asset.name.split('-');
+                        const version = nameParts.slice(2).join('-').replace('v', '').replace('.apk', '').replace('.zip','');
+                        const name = nameParts[0];
+
+                        nameCell.textContent = name;
+                        versionCell.textContent = version;
+                        link.href = asset.browser_download_url;
+                        link.textContent = 'Download';
+                        link.target = '_blank';
+
+                        linkCell.appendChild(link);
+                        row.appendChild(nameCell);
+                        row.appendChild(versionCell);
+                        row.appendChild(linkCell);
+                        table.appendChild(row);
+                    });
+                })
+                .catch(error => console.error('Error fetching release data:', error));
+        });
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Add a static website hosted on GitHub Pages listing all assets from the latest release with name, version, and link in a table with a material design style.

* **Add `docs/index.html`**:
  - Create an HTML file with a table listing all assets from the latest release.
  - Use Material Design for styling the table and the page.
  - Include columns for name, version, and link.
  - Fetch the latest release data from the GitHub API.
  - Apply a dark theme to the page.

* **Modify `.github/workflows/build.yml`**:
  - Add a step to generate the `index.html` file in the `docs` directory after a successful build and release.
  - Use a script to fetch the latest release data and generate the HTML file.
  - Ensure the `docs` directory is included in the repository.

* **Update `README.md`**:
  - Add a link to the static website hosted on GitHub Pages.
  - Provide a brief description of the website and its purpose.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/V1ck3s/revanced-apps?shareId=d4b18336-7f8b-4b73-abd1-90f62fecc2b5).